### PR TITLE
Set TRANSPARENT option in PNG output format

### DIFF
--- a/itasca.map
+++ b/itasca.map
@@ -64,6 +64,16 @@ MAP
     FORMATOPTION "STORAGE=memory"
   END
 
+  OUTPUTFORMAT
+    NAME "png"
+    DRIVER AGG/PNG
+    MIMETYPE "image/png"
+    IMAGEMODE RGB
+    EXTENSION "png"
+    FORMATOPTION "GAMMA=0.75"
+    TRANSPARENT TRUE
+  END
+
   #
   # Start of web interface definition (including WMS enabling metadata)
   #


### PR DESCRIPTION
This allows tiles / images to be transparent and view any base layers underneath. 
TRANSPARENT is not set in the default AGG/PNG output format: https://mapserver.org/mapfile/outputformat.html